### PR TITLE
Don't require Mongoid and Grape if not defined.

### DIFF
--- a/lib/garner.rb
+++ b/lib/garner.rb
@@ -20,5 +20,5 @@ require 'garner/strategies/cache/expiration_strategy'
 # caches
 require 'garner/cache/object_identity'
 # mixins
-require 'garner/mixins/grape_cache'
-require 'garner/mixins/mongoid_document'
+require 'garner/mixins/grape_cache' if defined?(Grape)
+require 'garner/mixins/mongoid_document' if defined?(Mongoid)


### PR DESCRIPTION
I'm using Garner in conjunction with Grape and Rails 2.3. I added the if defined? checks so the gem will work in my environment which it does now. Thanks for the suggestion Daniel!
