### PR TITLE
@dblock: Fix for calling helpers like find_cached_by_slug in an IRB session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Next Release
 ------------
 * Fix: `invalidate` no longer writes a new index key for each object binding; instead it only deletes existing index keys.
+* Fix: Invoking Garner helper methods from within an IRB session no longer crashes inside the `Keys::Caller` strategy.
 
 0.1.3
 -----

--- a/lib/garner/strategies/keys/caller_strategy.rb
+++ b/lib/garner/strategies/keys/caller_strategy.rb
@@ -14,8 +14,8 @@ module Garner
             caller.each do |line|
               split = line.split(":")
               next unless split.length >= 2
-              path = Pathname.new(split[0]).realpath.to_s
-              next if path.include?("lib/garner")
+              path = (Pathname.new(split[0]).realpath.to_s rescue nil)
+              next if path.blank? || path.include?("lib/garner")
               next unless path.include?("/app/") || path.include?("/spec/")
               rc[field] = "#{path}:#{split[1]}"
               break


### PR DESCRIPTION
Fixes #3. This was preventing me from debugging a cache issue this morning, so fixed.

Wanted to write a spec, but not sure if it's possible. Stubbing `Kernel.caller` has unintended effects. For example, the following RSpec example doesn't work:

``` ruby
it "does not choke on IRB sessions" do
  Kernel.stub(:caller) { ["(irb):0:in `get_awesome`"] }
  subject.apply({})[:caller].should_not raise_error
end
```
