### PR TITLE
@dblock: Attempt to fix build by top-namespacing class reference

### DIFF
--- a/spec/support/test_model_child.rb
+++ b/spec/support/test_model_child.rb
@@ -1,5 +1,5 @@
 class TestModelChild
   include Mongoid::Document
   include Garner::Mixins::Mongoid::Document
-  cache_as TestModel
+  cache_as ::TestModel
 end


### PR DESCRIPTION
Not sure if this will actually fix the issue, or why it's consistently failing on Travis. I can't reproduce locally in any environment, even on fresh gemsets.
