### PR TITLE
Mention usage of generational cache key components in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ Garner::Cache::ObjectIdentity.cache({ bind: [ Model, { id: object_id }] }) do
 end
 ```
 
+When fetching directly from the cache, it may be useful to supply a generational cache key in addition to the bindings. (When the generational component changes, the cache result is invalidated independent of the bindings' state.) E.g.:
+
+```ruby
+Garner::Cache::ObjectIdentity.cache(bind: [Model, {id: object_id}], key: {v: '1'}) do
+  # ...
+end
+```
+
+Or, using the Grape mix-in:
+
+```ruby
+cache_or_304(bind: [User, current_user.id], key: {v: '1'}) do
+  # ...
+end
+```
+
 Various cache stores, including Memcached, support bulk read operations. The [Dalli gem](https://github.com/mperham/dalli) exposes this via the `read_multi` method. When invoked with a collection of bindings, Garner will call `read_multi` if available. This may significantly reduce the number of network roundtrips to the cache servers.
 
 ``` ruby


### PR DESCRIPTION
I found it useful to be able to invalidate a the cache result of a `cache_or_304` block independent of the bindings (e.g., when logic underlying the block's result is updated).

Thanks @macreery for pointing me in the right direction.

Nicely formatted view of the full file with changes is [here](https://github.com/joeyAghion/garner/blob/4b6c6b17e955d6aab74534f42112566f7fe5abd8/README.md#fetching-objects-directly-from-cache).
