### PR TITLE
Fix: Stale cache on :destroy for class-bound results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed the `Garner.config.mongoid_binding_key_strategy` and `Garner.config.mongoid_invalidation_key_strategy`. Garner now uses just one default key/invalidation strategy pair for all binding types.
 * Added an ActiveRecord mixin, `Garner::Mixins::ActiveRecord::Base`, per #35.
 * Eliminated the need to `require "garner/mixins/rack"` before declaring `Garner.config.rack_context_key_strategies`, per #35.
+* Fixed a bug in binding to classes via the `SafeCacheKey` and `Touch` strategy pair, where class-bound results would not be invalidated when an instance of the class was destroyed.
 
 0.4.0 (6/14/2013)
 -----------------

--- a/lib/garner/mixins/mongoid/document.rb
+++ b/lib/garner/mixins/mongoid/document.rb
@@ -16,14 +16,16 @@ module Garner
             _latest_by_updated_at
           end
 
-          def self.identify(id)
-            Garner::Mixins::Mongoid::Identity.from_class_and_id(self, id)
+          def self.identify(handle)
+            Mongoid::Identity.from_class_and_handle(self, handle)
           end
 
-          def self.garnered_find(id)
-            return nil unless (binding = identify(id))
+          def self.garnered_find(handle)
+            return nil unless (binding = identify(handle))
             identity = Garner::Cache::Identity.new
-            identity.bind(binding).key({ :source => :garnered_find }) { find(id) }
+            identity.bind(binding).key({ :source => :garnered_find }) do
+              find(handle)
+            end
           end
 
           after_create    :_garner_after_create

--- a/lib/garner/strategies/binding/invalidation/touch.rb
+++ b/lib/garner/strategies/binding/invalidation/touch.rb
@@ -8,7 +8,10 @@ module Garner
           #
           # @param kind [Symbol] One of :create, :update, :destroy
           def self.apply_on_callback?(kind = nil)
-            false
+            # Only apply on destruction, so that class bindings remain
+            # valid, if the destroyed binding was not also the previous
+            # proxy_binding.
+            !!(kind == :destroy)
           end
 
           # Force-invalidate an object binding. Used when bindings are
@@ -17,7 +20,17 @@ module Garner
           # @param binding [Object] The binding whose caches are to be
           #   invalidated.
           def self.apply(binding)
-            binding = binding.proxy_binding if binding.respond_to?(:proxy_binding)
+            if  binding.respond_to?(:destroyed?) &&
+                binding.destroyed? &&
+                binding.class.respond_to?(:proxy_binding)
+              # Binding is destroyed, but we must ensure that its class's
+              # proxy_binding is touched, if necessary.
+              binding = binding.class.proxy_binding
+
+            elsif binding.respond_to?(:proxy_binding)
+              binding = binding.proxy_binding
+            end
+
             binding.touch if binding.respond_to?(:touch)
           end
         end

--- a/spec/garner/mixins/mongoid/identity_spec.rb
+++ b/spec/garner/mixins/mongoid/identity_spec.rb
@@ -9,7 +9,7 @@ describe Garner::Mixins::Mongoid::Identity do
     @mock_mongoid_strategy.stub(:apply)
   end
 
-  describe "from_class_and_id" do
+  describe "from_class_and_handle" do
     before(:each) do
       Garner.configure do |config|
         config.mongoid_identity_fields = [:_id, :_slugs]
@@ -20,23 +20,24 @@ describe Garner::Mixins::Mongoid::Identity do
 
     it "raises an exception if called on a non-Mongoid class" do
       expect {
-        subject.from_class_and_id(Class.new, "id")
+        subject.from_class_and_handle(Class.new, "id")
       }.to raise_error
 
       expect {
-        subject.from_class_and_id(Monger.new, "id")
+        subject.from_class_and_handle(Monger.new, "id")
       }.to raise_error
     end
 
     it "raises an exception if called on an embedded document" do
       expect {
-        subject.from_class_and_id(Fish, "id")
+        subject.from_class_and_handle(Fish, "id")
       }.to raise_error
     end
 
-    it "sets collection_name and a conditions hash" do
-      identity = subject.from_class_and_id(Monger, "id")
-      identity.collection_name.should == :mongers
+    it "sets klass, handle and a conditions hash" do
+      identity = subject.from_class_and_handle(Monger, "id")
+      identity.klass.should == Monger
+      identity.handle.should == "id"
       identity.conditions["$or"].should == [
         { :_id => "id" },
         { :_slugs => "id" }
@@ -44,9 +45,9 @@ describe Garner::Mixins::Mongoid::Identity do
     end
 
     context "on a Mongoid subclass" do
-      it "sets collection_name to parent and includes the _type field" do
-        identity = subject.from_class_and_id(Cheese, "id")
-        identity.collection_name.should == :foods
+      it "sets klass to parent and includes the _type field" do
+        identity = subject.from_class_and_handle(Cheese, "id")
+        identity.klass.should == Cheese
         identity.conditions[:_type].should == { "$in" => ["Cheese"] }
         identity.conditions["$or"].should == [
           { :_id => "id" },
@@ -66,40 +67,45 @@ describe Garner::Mixins::Mongoid::Identity do
       @cheese = Cheese.create({ :name => "Havarti" })
     end
 
-    describe "cache_key" do
-      it "generates a cache key equal to Mongoid::Document's" do
-        Monger.identify("m1").cache_key.should == @monger.cache_key
-
-        # Also test for Mongoid subclasses
-        Cheese.identify("havarti").cache_key.should == @cheese.cache_key
-        Food.identify("havarti").cache_key.should == @cheese.cache_key
-        Monger.identify("m2").cache_key.should == Monger.new({ :name => "M2" }).cache_key
+    describe "proxy_binding" do
+      it "returns nil for nonexistent bindings" do
+        Monger.identify("m2").proxy_binding.should be_nil
       end
 
-      context "without Mongoid::Timestamps" do
-        before(:each) do
-          @monger.unset(:updated_at)
-          @cheese.unset(:updated_at)
-        end
-
+      describe "cache_key" do
         it "generates a cache key equal to Mongoid::Document's" do
-          Monger.identify("m1").cache_key.should == @monger.cache_key
+          Monger.identify("m1").proxy_binding.cache_key.should == @monger.cache_key
 
           # Also test for Mongoid subclasses
-          Cheese.identify("havarti").cache_key.should == @cheese.cache_key
-          Food.identify("havarti").cache_key.should == @cheese.cache_key
+          Cheese.identify("havarti").proxy_binding.cache_key.should == @cheese.cache_key
+          Food.identify(@cheese.id).proxy_binding.cache_key.should == @cheese.cache_key
+        end
+
+        context "without Mongoid::Timestamps" do
+          before(:each) do
+            @monger.unset(:updated_at)
+            @cheese.unset(:updated_at)
+          end
+
+          it "generates a cache key equal to Mongoid::Document's" do
+            Monger.identify("m1").proxy_binding.cache_key.should == @monger.cache_key
+
+            # Also test for Mongoid subclasses
+            Cheese.identify("havarti").proxy_binding.cache_key.should == @cheese.cache_key
+            Food.identify(@cheese.id).proxy_binding.cache_key.should == @cheese.cache_key
+          end
+        end
+      end
+      describe "updated_at" do
+        it "returns :updated_at equal to Mongoid::Document's" do
+          Monger.identify("m1").proxy_binding.updated_at.should == Monger.find("m1").updated_at
+
+          # Also test for Mongoid subclasses
+          Cheese.identify("havarti").proxy_binding.updated_at.should == @cheese.reload.updated_at
+          Food.identify(@cheese.id).proxy_binding.updated_at.should == @cheese.reload.updated_at
         end
       end
     end
-    describe "updated_at" do
-      it "returns :updated_at equal to Mongoid::Document's" do
-        Monger.identify("m1").updated_at.should == Monger.find("m1").updated_at
 
-        # Also test for Mongoid subclasses
-        Cheese.identify("havarti").updated_at.should == Cheese.identify("havarti").updated_at
-        Food.identify("havarti").updated_at.should == Food.identify("havarti").updated_at
-        Monger.identify("m2").updated_at.should == Monger.new({ :name => "M2" }).updated_at
-      end
-    end
   end
 end

--- a/spec/garner/strategies/binding/key/cache_key_spec.rb
+++ b/spec/garner/strategies/binding/key/cache_key_spec.rb
@@ -14,7 +14,9 @@ describe Garner::Strategies::Binding::Key::CacheKey do
     let(:unknown_bindings) { [@mock.class] }
   end
 
-  it "returns the object's cache key, or nil" do
-    subject.apply(@mock).should == "mocks/4"
+  describe "apply" do
+    it "returns the object's cache key, or nil" do
+      subject.apply(@mock).should == "mocks/4"
+    end
   end
 end

--- a/spec/garner/strategies/binding/key/safe_cache_key_spec.rb
+++ b/spec/garner/strategies/binding/key/safe_cache_key_spec.rb
@@ -18,23 +18,24 @@ describe Garner::Strategies::Binding::Key::SafeCacheKey do
     let(:unknown_bindings) { [@new_mock] }
   end
 
-  it "returns the object's cache key + milliseconds if defined" do
-    timestamp = @time_dot_now.utc.to_s(:number)
+  describe "apply" do
+    it "returns the object's cache key + milliseconds if defined" do
+      timestamp = @time_dot_now.utc.to_s(:number)
+      subject.apply(@persisted_mock).should =~ /^mocks\/4-#{timestamp}.[0-9]{10}$/
+    end
 
-    subject.apply(@persisted_mock).should =~ /^mocks\/4-#{timestamp}.[0-9]{10}$/
-  end
+    it "returns nil if :cache_key is undefined or nil" do
+      @persisted_mock.unstub(:cache_key)
+      subject.apply(@persisted_mock).should be_nil
+      @persisted_mock.stub(:cache_key) { nil }
+      subject.apply(@persisted_mock).should be_nil
+    end
 
-  it "returns nil if :cache_key is undefined or nil" do
-    @persisted_mock.unstub(:cache_key)
-    subject.apply(@persisted_mock).should be_nil
-    @persisted_mock.stub(:cache_key) { nil }
-    subject.apply(@persisted_mock).should be_nil
-  end
-
-  it "returns nil if :updated_at is undefined or nil" do
-    @persisted_mock.unstub(:updated_at)
-    subject.apply(@persisted_mock).should be_nil
-    @persisted_mock.stub(:updated_at) { nil }
-    subject.apply(@persisted_mock).should be_nil
+    it "returns nil if :updated_at is undefined or nil" do
+      @persisted_mock.unstub(:updated_at)
+      subject.apply(@persisted_mock).should be_nil
+      @persisted_mock.stub(:updated_at) { nil }
+      subject.apply(@persisted_mock).should be_nil
+    end
   end
 end

--- a/spec/support/cache.rb
+++ b/spec/support/cache.rb
@@ -7,3 +7,10 @@ if (server = ENV["GARNER_MEMCACHE_SERVER"])
     })
   end
 end
+
+# Purge cache before each test example
+RSpec.configure do |config|
+  config.before(:each) do
+    Garner.config.cache.clear
+  end
+end


### PR DESCRIPTION
to: @joeyAghion

This fixes a bug in binding to classes via the `SafeCacheKey` and `Touch` strategy pair, where class-bound results would not be invalidated when an instance of the class was destroyed.

A spec demonstrating the problem case is:

``` ruby
def cached_object_name_concatenator
  garner.bind(Cheese) { Cheese.all.order_by(:_id => :asc).map(&:name).join(", ") } 
end

it "invalidates on destroy" do
  m1 = Cheese.create({ :name => "M1" })
  m3 = Cheese.create({ :name => "M3" })
  cached_object_name_concatenator.call.should == "M1, M3"
  m1.destroy
  cached_object_name_concatenator.call.should == "M3"
end
```

Because the `Cheese` class uses its most recently updated document as its "proxy binding," the destruction of any document other than the most recently updated one causes `Cheese`-bound results to go stale. I'm not convinced that my solution is ideal, especially since:
1. It introduces an assumption about how class and instance bindings interact, and
2. It requires updating the `:updated_at` of an unmodified document.

But I couldn't think of a more elegant alternative. Any ideas? Here's the crux of the solution, in touch.rb:

``` ruby
if  binding.respond_to?(:destroyed?) &&
    binding.destroyed? &&
    binding.class.respond_to?(:proxy_binding)
  # Binding is destroyed, but we must ensure that its class's
  # proxy_binding is touched, if necessary.
  binding = binding.class.proxy_binding
  binding.touch if binding.respond_to?(:touch)
end
```
