### PR TITLE
Fix: Rails.root is a Pathname, not a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Next Release (TBD)
 ------------------
 
+0.4.2 (6/28/2013)
+-----------------
+* Fixed `Caller` strategy when using Rails.
+
 0.4.1 (6/28/2013)
 -----------------
 * Added a `rake benchmark` task to compare different binding key/invalidation strategy pairs.

--- a/garner.gemspec
+++ b/garner.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "garner"
-  s.version = "0.4.1"
+  s.version = "0.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Daniel Doubrovkine", "Frank Macreery"]
-  s.date = "2013-06-28"
+  s.date = "2013-06-29"
   s.description = "Garner is a cache layer for Ruby and Rack applications, supporting model and instance binding and hierarchical invalidation."
   s.email = "dblock@dblock.org"
   s.extra_rdoc_files = [

--- a/lib/garner/config.rb
+++ b/lib/garner/config.rb
@@ -111,7 +111,7 @@ module Garner
     #
     # @return [String] The newly set caller_root.
     def caller_root=(caller_root)
-      settings[:caller_root] = caller_root
+      settings[:caller_root] = caller_root && caller_root.to_s
     end
 
     # Reset the configuration options to the defaults.

--- a/lib/garner/strategies/context/key/caller.rb
+++ b/lib/garner/strategies/context/key/caller.rb
@@ -18,7 +18,7 @@ module Garner
           # @return [String] The default root path.
           def self.default_root
             if defined?(::Rails) && ::Rails.respond_to?(:root)
-              ::Rails.root
+              ::Rails.root.realpath.to_s
             else
               # Try to use the nearest ancestor directory containing a Gemfile.
               requiring_caller = send(:caller).detect do |line|

--- a/lib/garner/version.rb
+++ b/lib/garner/version.rb
@@ -1,3 +1,3 @@
 module Garner
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/spec/garner/strategies/context/key/caller_spec.rb
+++ b/spec/garner/strategies/context/key/caller_spec.rb
@@ -53,15 +53,15 @@ describe Garner::Strategies::Context::Key::Caller do
     before(:each) do
       class ::Rails
       end
-      ::Rails.stub(:root) { File.dirname(__FILE__) }
+      ::Rails.stub(:root) { Pathname.new(File.dirname(__FILE__)) }
     end
 
     it "sets default_root to Rails.root" do
-      subject.default_root.should == ::Rails.root
+      subject.default_root.should == ::Rails.root.realpath.to_s
     end
 
     it "sets Garner.config.caller_root to Rails.root" do
-      Garner.config.caller_root.should == ::Rails.root
+      Garner.config.caller_root.should == ::Rails.root.realpath.to_s
     end
 
     it "sets an appropriate value for :caller" do


### PR DESCRIPTION
Was getting the following error in a Rails context:

```
NoMethodError:
  undefined method `[]' for #<Pathname:/path/to/project/folder>
```
