### PR TITLE
[Do Not Merge] Example of BindingIndex invalidation strategy's failure to handle reused (non-unique) identities.

### DIFF
--- a/spec/integration/mongoid_spec.rb
+++ b/spec/integration/mongoid_spec.rb
@@ -224,6 +224,36 @@ describe "Mongoid integration" do
               end
             end
           end
+
+          context "with non-unique identities" do
+            before(:each) do
+              Garner.configure do |config|
+                config.mongoid_identity_fields = [:_id, :_slugs]
+              end
+
+              class Other
+                include Mongoid::Document
+                include Mongoid::Slug
+
+                field :name, :type => String
+                slug :name
+              end
+            end
+
+            it "honors objects that take another object's identity" do
+              one = Other.create!({ :name => "foo" })
+              garnered_one = Other.garnered_find("foo")
+              garnered_one.should == one
+
+              one.update_attributes!({ :name => "bar" })
+
+              two = Other.create!({ :name => "foo" })
+              garnered_one = Other.garnered_find("bar")
+              garnered_two = Other.garnered_find("foo")
+              garnered_one.should == one
+              garnered_two.should == two
+            end
+          end
         end
 
         context "binding at the class level" do


### PR DESCRIPTION
Don't merge this, as it's just a failing spec to demonstrate the failure of the `BindingIndex` invalidation strategy to handle `Mongoid::Identity` bindings in cases where the document class uses non-unique slugs (i.e., `slug` without `{ :history => true }`), and a slug gets reused on two different objects.

This is representative of a more general issue, where the `BindingIndex` invalidation strategy (by design) never updates the canonical binding reference for non-canonical bindings. So, if an invalid value is ever written to the canonical binding reference, the cache will never heal (except by calling `invalidate_garner_caches` directly on the **non-canonical binding**).

My opinion is that the current behavior should not be modified, but I wanted to at least document the issue.

cc: @dblock @dylanfareed
