### PR TITLE
Failing spec for garnered_find not respecting chained criteria

### DIFF
--- a/spec/integration/mongoid_spec.rb
+++ b/spec/integration/mongoid_spec.rb
@@ -26,6 +26,9 @@ describe "Mongoid integration" do
         context "binding at the instance level" do
           before(:each) do
             @object = Monger.create!({ :name => "M1" })
+            @monger_who_is_a_thug = Monger.create!({ :name => 'Philly' })
+            @whiz = Cheese.create!({ :name => 'whiz', monger: @monger_who_is_a_thug })
+            @cheddar = Cheese.create!({ :name => 'cheddar', monger: @object })
           end
 
           describe "garnered_find" do
@@ -33,6 +36,11 @@ describe "Mongoid integration" do
               Garner.configure do |config|
                 config.mongoid_identity_fields = [:_id, :_slugs]
               end
+            end
+
+            it "respects criteria" do
+              Cheese.garnered_find("cheddar").should == @cheddar
+              @monger_who_is_a_thug.cheeses.garnered_find("cheddar").should be_nil
             end
 
             it "caches one copy across all callers" do


### PR DESCRIPTION
Ahoy there!

Here is a failing spec that shows `garnered_find` not respecting chained criteria.

I would expect `@monger_who_is_a_thug.cheeses.garnered_find("cheddar")` to return nothing, since cheddar is not one of this monger's cheeses.

I'm realizing in our API, we do build up scopes/chain criteria and then call garnered_find at the end on some object. This means that someone can make an API call for something they are authorized for, but pass in an object id for something else and get it. Something like `partner.artworks.garnered_find(id)` means that if you pass in the id of _any_ artwork, as long as you have access to the given partner, you'll be able to get the details of a completely different private work.

Let me know if you think this is something we should fix in Garner, I'll try it out. I am thinking that the criteria used for the lookup needs to be added to the identity.
