### PR TITLE
Fix: ActiveRecord 4 cache_key is now in :nsec format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 doc
 pkg
 log
+.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ services:
 
 rvm:
   - 1.9.3
+  - 2.1.2
+  - rbx-2
 
+env:
+  - MONGOID_VERSION=3
+  - MONGOID_VERSION=4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 Next Release
 ------------
+
 * [#70](https://github.com/artsy/garner/pull/70): Added a `whiny_nils` configuration variable (default: `true`) which determines whether Garner raises exceptions on `nil` bindings - [@fancyremarker](https://github.com/fancyremarker).
+* [#72](https://github.com/artsy/garner/issues/72): Fix: ActiveRecord 4 support, `cache_key` is now in `:nsec` format - [@dblock](https://github.com/dblock).
+* Your contribution here.
 
 0.4.5 (10/15/2013)
 -----------------
+
 * Fixed [#62](https://github.com/artsy/garner/issues/62): fix garnered_find in `Garner::Mixins::Mongoid::Document.garnered_find` to support finding multiple objects, matching Mongoid's find - [@mzikherman](https://github.com/mzikherman).
 * Fixed [#60](https://github.com/artsy/garner/issues/60): don't return cache keys for Mongoid::Document#identify(nil) - [@fancyremarker](https://github.com/fancyremarker).
 
 0.4.4 (7/11/2013)
 -----------------
+
 * Fixed [#47](https://github.com/artsy/garner/issues/47): use a database index when generating proxy binding in `Garner::Mixins::Mongoid::Identity` with multiple `Garner.config.mongoid_identity_fields` - [@dblock](https://github.com/dblock).
 
 0.4.3 (7/5/2013)
 ----------------
+
 * Stored `ruby_context` from which a `Garner::Cache::Identity` was initialized as an `attr_accessor` on the object - [@fancyremarker](https://github.com/fancyremarker).
 * Fixed `cache_enabled?` logic and added a `nocache` declaration to `Garner::Cache::Identity` - [@fancyremarker](https://github.com/fancyremarker).
 * Fixed #44, in which the BindingIndex was mistakenly storing values to cache for bindings with a nil canonical binding - [@fancyremarker](https://github.com/fancyremarker).
@@ -20,10 +26,12 @@ Next Release
 
 0.4.2 (6/28/2013)
 -----------------
+
 * Fixed `Caller` strategy when using Rails - [@fancyremarker](https://github.com/fancyremarker).
 
 0.4.1 (6/28/2013)
 -----------------
+
 * Added a `rake benchmark` task to compare different binding key/invalidation strategy pairs - [@fancyremarker](https://github.com/fancyremarker).
 * Improved the performance of the `SafeCacheKey` strategy on virtual `Garner::Mixins::Mongoid::Identity` bindings by properly memoizing the corresponding document - [@fancyremarker](https://github.com/fancyremarker).
 * Improved the performance of the `SafeCacheKey` strategy on class bindings by making 1 database call per key application, instead of 3 - [@fancyremarker](https://github.com/fancyremarker).

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,21 @@ gem "multi_json",   ">= 1.3.0"
 gem "activesupport"
 
 group :development, :test do
-  gem "bundler",    ">= 1.3.0"
-  gem "grape",      ">= 0.2.0"
+  gem "bundler"
+  gem "grape",      "~> 0.8.0"
   gem "sinatra"
   gem "rack-test"
-  gem "rspec",      "~> 2.10"
+  gem "rspec",      "~> 2.10.0"
   gem "jeweler"
-  gem "mongoid",    "~> 3.0"
-  gem "mongoid_slug", ">= 1.0.0"
+  case version = ENV['MONGOID_VERSION'] || '~> 4.0'
+  when /4/
+    gem 'mongoid', '~> 4.0'
+  when /3/
+    gem 'mongoid', '~> 3.1'
+  else
+    gem 'mongoid', version
+  end
+  gem "mongoid_slug"
   gem "dalli"
   gem "activerecord"
   gem "sqlite3"

--- a/lib/garner/strategies/binding/key/safe_cache_key.rb
+++ b/lib/garner/strategies/binding/key/safe_cache_key.rb
@@ -3,7 +3,7 @@ module Garner
     module Binding
       module Key
         class SafeCacheKey < Base
-          VALID_FORMAT = /^(?<model>[^\/]+)\/(?<id>.+)-(?<timestamp>[0-9]{14})$/
+          VALID_FORMAT = /^(?<model>[^\/]+)\/(?<id>.+)-(?<timestamp>[0-9]{14,})$/
 
           # Compute a cache key from an object binding. Only return a key if
           # :cache_key and :updated_at are both defined and present on the

--- a/spec/garner/mixins/mongoid/identity_spec.rb
+++ b/spec/garner/mixins/mongoid/identity_spec.rb
@@ -97,7 +97,7 @@ describe Garner::Mixins::Mongoid::Identity do
       end
 
       it "limits the query" do
-        Mongoid::Criteria.any_instance.should_receive(:limit).and_return([ @m ])
+        Mongoid::Slug::Criteria.any_instance.should_receive(:limit).with(1).and_return([ @monger ])
         Monger.identify("m1").proxy_binding
       end
 

--- a/spec/integration/active_record_spec.rb
+++ b/spec/integration/active_record_spec.rb
@@ -16,7 +16,7 @@ describe "ActiveRecord integration" do
         subject.apply(new_activist).should == "activists/new"
 
         persisted_activist = Activist.create
-        timestamp = persisted_activist.updated_at.utc.to_s(:number)
+        timestamp = persisted_activist.updated_at.utc.to_s(persisted_activist.cache_timestamp_format)
         expected_key = "activists/#{persisted_activist.id}-#{timestamp}"
         subject.apply(persisted_activist).should == expected_key
       end

--- a/spec/integration/mongoid_spec.rb
+++ b/spec/integration/mongoid_spec.rb
@@ -83,7 +83,7 @@ describe "Mongoid integration" do
               it "returns the instances requested" do
                 Monger.garnered_find("m1", "m2").should == [ @object, @object2 ]
               end
-              
+
               it "can take an array" do
                 Monger.garnered_find([ "m1", "m2" ]).should == [ @object, @object2 ]
               end
@@ -155,15 +155,22 @@ describe "Mongoid integration" do
 
               it "invalidates by explicit call to invalidate_garner_caches" do
                 cached_object_namer.call.should == "M1"
-                @object.set(:name, "M2")
+                if Mongoid.mongoid3?
+                  @object.set(:name, "M2")
+                else
+                  @object.set(name: "M2")
+                end
                 @object.invalidate_garner_caches
                 cached_object_namer.call.should == "M2"
               end
 
               it "does not invalidate results for other like-classed objects" do
                 cached_object_namer.call.should == "M1"
-                @object.set({ :name => "M2" })
-
+                if Mongoid.mongoid3?
+                  @object.set(:name, "M2")
+                else
+                  @object.set(name: "M2")
+                end
                 new_monger = Monger.create!({ :name => "M3" })
                 new_monger.update_attributes!({ :name => "M4" })
                 new_monger.destroy
@@ -180,7 +187,11 @@ describe "Mongoid integration" do
                 it "invalidates caches properly (Type I)" do
                   cached_object_namer.call
                   @monger1.remove
-                  @monger2.set(:name, "M2")
+                  if Mongoid.mongoid3?
+                    @monger2.set(:name, "M2")
+                  else
+                    @monger2.set(name: "M2")
+                  end
                   @monger1.destroy
                   @monger2.save
                   cached_object_namer.should raise_error
@@ -188,7 +199,11 @@ describe "Mongoid integration" do
 
                 it "invalidates caches properly (Type II)" do
                   cached_object_namer.call
-                  @monger2.set(:name, "M2")
+                  if Mongoid.mongoid3?
+                    @monger2.set(:name, "M2")
+                  else
+                    @monger2.set(name: "M2")
+                  end
                   @monger1.remove
                   @monger2.save
                   @monger1.destroy
@@ -325,7 +340,11 @@ describe "Mongoid integration" do
                 m1 = Cheese.create({ :name => "M1" })
                 m3 = Cheese.create({ :name => "M3" })
                 cached_object_name_concatenator.call.should == "M1, M3"
-                m1.set(:name, "M2")
+                if Mongoid.mongoid3?
+                  m1.set(:name, "M2")
+                else
+                  m1.set(name: "M2")
+                end
                 klass.invalidate_garner_caches
                 cached_object_name_concatenator.call.should == "M2, M3"
               end

--- a/spec/support/mongoid.rb
+++ b/spec/support/mongoid.rb
@@ -10,8 +10,7 @@ Mongoid.load_configuration({
     }
   },
   :options => {
-    :raise_not_found_error => false,
-    :identity_map_enabled => false
+    :raise_not_found_error => false
   }
 })
 
@@ -24,6 +23,10 @@ end
 module Mongoid
   module Document
     include Garner::Mixins::Mongoid::Document
+  end
+
+  def self.mongoid3?
+    ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x
   end
 end
 


### PR DESCRIPTION
Fixes #72.

Added testing w/both Mongoid 3 and 4, Ruby 2.x and RBX. Tried JRuby, but there're some gem issues, will work on that separately, #75.
