### PR TITLE
@fancyremarker => Fixed #81: Garner.cache loses namespace options when calling delete when cache block yields nil.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.5.1 (Next)
 ------------
 
+* Fixed [#81](https://github.com/artsy/garner/issues/81): `Garner.cache` loses namespace options when calling delete when cache block yields `nil` - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 0.5.0 (7/17/2014)

--- a/lib/garner/cache.rb
+++ b/lib/garner/cache.rb
@@ -13,7 +13,7 @@ module Garner
         result = Garner.config.cache.fetch(compound_key, options_hash) do
           yield
         end
-        Garner.config.cache.delete(compound_key) unless result
+        Garner.config.cache.delete(compound_key, options_hash) unless result
       else
         result = yield
       end

--- a/spec/garner/cache_spec.rb
+++ b/spec/garner/cache_spec.rb
@@ -45,5 +45,13 @@ describe Garner::Cache do
       Garner.configure { |config| config.whiny_nils = false }
       expect { subject.fetch([nil], {}, {}) { 'foo' } }.not_to raise_error
     end
+
+    it 'deletes record when cached block yields nil' do
+      binding = double('object', garner_cache_key: 'key')
+      expect(Garner.config.cache).to receive(:delete).with({ binding_keys: ['key'], context_keys: { key: 'value' } }, { namespace: 'foo' })
+      subject.fetch [binding], { key: 'value' }, namespace: 'foo' do
+        nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This looks about right. I think we just need to pass the options through. I couldn't construct an integration test that would reproduce a real problem though.
