### PR TITLE
Update the Conference Video URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Garner
 
 Garner is a cache layer for Ruby and Rack applications, supporting model and instance binding and hierarchical invalidation. To "garner" means to gather data from various sources and to make it readily available in one place, kind of like a cache!
 
-If you're not familiar with HTTP caching, ETags and If-Modified-Since, watch us introduce Garner in [From Zero to API Cache in 10 Minutes](http://www.confreaks.com/videos/986-goruco2012-from-zero-to-api-cache-w-grape-mongodb-in-10-minutes) at GoRuCo 2012.
+If you're not familiar with HTTP caching, ETags and If-Modified-Since, watch us introduce Garner in [From Zero to API Cache in 10 Minutes](https://www.youtube.com/watch?v=e9HLflRXMcA) at GoRuCo 2012.
 
 Upgrading
 ---------


### PR DESCRIPTION
Problem

The current conference video url links to a 404 page.

Solution

Update the video url to reference the video on Confreaks YouTube
channel.

#trivial